### PR TITLE
Fix compiler warnings

### DIFF
--- a/common.cc
+++ b/common.cc
@@ -49,7 +49,7 @@ call_entry(std::vector<double> samples, int nominal_start,
         {
           static int seq = 0;
           char file[128];
-          sprintf(file, "r%03d.wav", seq);
+          snprintf(file, sizeof(file)-1, "r%03d.wav", seq);
           seq++;
           display_status = std::string("writing ") + file;
           std::vector<double> xx = samples;

--- a/fate.cc
+++ b/fate.cc
@@ -487,12 +487,12 @@ draw_screen()
   // --- first divider.
   char info[64];
   if(rx_call != ""){
-    sprintf(info, "---- RX %s HZ=%.0f SNR=%.0f ",
+    snprintf(info, sizeof(info)-1,  "---- RX %s HZ=%.0f SNR=%.0f ",
             rx_call.c_str(),
             rx_hz,
             rx_snr);
   } else {
-    sprintf(info, "---- RX - HZ= SNR= ");
+    snprintf(info, sizeof(info)-1,  "---- RX - HZ= SNR= ");
   }
   printf("%s", info);
   for(int i = 0; i < lay.cols - (int) strlen(info) - 1; i++)
@@ -510,9 +510,9 @@ draw_screen()
 
   // --- second divider.
   if(tx_hz > 0){
-    sprintf(info, "---- TX HZ=%.0f ", tx_hz);
+    snprintf(info, sizeof(info)-1,  "---- TX HZ=%.0f ", tx_hz);
   } else {
-    sprintf(info, "---- TX HZ= ");
+    snprintf(info, sizeof(info)-1,  "---- TX HZ= ");
   }
   printf("%s", info);
   for(int i = 0; i < lay.cols - (int) strlen(info) - 1; i++)

--- a/unpack.cc
+++ b/unpack.cc
@@ -542,14 +542,14 @@ unpack(const int a87[87], std::string &other_call)
     return "CompoundDirected";
   } else {
     char buf[512];
-    sprintf(buf, "can't parse, starts with %d %d %d\n",
+    snprintf(buf, sizeof(buf)-1, "can't parse, starts with %d %d %d\n",
             a87[0], a87[1], a87[2]);
     return std::string(buf);
   }
 
 #if 0
   char anno[64];
-  sprintf(anno, " <%d%d%d, %d%d%d>", 
+  snprintf(anno, sizeof(anno)-1, " <%d%d%d, %d%d%d>", 
           a87[0], a87[1], a87[2],
           a87[72], a87[73], a87[74]);
   msg += std::string(anno);


### PR DESCRIPTION
Changed sprintf calls to snprintf calls to eliminate deprecation warnings as well as prevent possible buffer overflows.